### PR TITLE
Create Fixer for Readonly Properties

### DIFF
--- a/.github/workflows/GithubProject.yaml
+++ b/.github/workflows/GithubProject.yaml
@@ -1,0 +1,15 @@
+name: Github Projects
+
+on:
+  pull_request:
+    types: [opened, reopened ]
+
+jobs:
+  add-to-project:
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/clinkards/projects/7
+          github-token: ${{ secrets.GHPROJECT_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,17 @@
+name: CD - Notify Registry
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  package:
+    timeout-minutes: 6
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
+        repository: clinkards/php-composer-registry
+        event-type: package_release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+    - "*"
+
+jobs:
+  codestyle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        tools: composer:v2
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest --no-interaction --no-scripts --no-plugins
+    - name: Run PHP CS Fixer
+      run: composer phpcs
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: [codestyle]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        tools: composer:v2
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest --no-interaction --no-scripts --no-plugins
+    - name: Run PHPUnit
+      run: composer test

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,18 @@
     "php": "^8.0|^8.1|^8.2",
     "friendsofphp/php-cs-fixer": "^3.16"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^11.1"
+  },
   "autoload": {
     "psr-4": {
       "Clinkards\\PhpCsFixerConfig\\": "src/"
     }
   },
   "scripts": {
-    "phpcs-fix" : "vendor/bin/php-cs-fixer fix --using-cache=no --ansi",
-    "phpcs": "vendor/bin/php-cs-fixer fix --diff --dry-run  --ansi"
+    "phpcs-fix" : "vendor/bin/php-cs-fixer fix --allow-risky=yes --using-cache=no --ansi",
+    "phpcs": "vendor/bin/php-cs-fixer fix --diff --dry-run --allow-risky=yes --ansi",
+    "test": "phpunit"
   },
   "scripts-descriptions": {
     "phpcs": "Runs coding style test suite"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="CustomFixers">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,7 @@
 
 namespace Clinkards\PhpCsFixerConfig;
 
+use Clinkards\PhpCsFixerConfig\Sniffs\RemoveReadonlyPropertyAttributeOnReadonlyClass;
 use PhpCsFixer\Config as BaseConfig;
 
 class Config extends BaseConfig
@@ -14,11 +15,16 @@ class Config extends BaseConfig
         'no_unused_imports' => true,
         'declare_strict_types' => true,
         'fully_qualified_strict_types' => false,
+        'Clinkards/remove_readonly_property' => true,
     ];
 
     public function __construct(private array $extraRules = [])
     {
         parent::__construct('Clinkards - Coding Standard');
+
+        $this->registerCustomFixers([
+            new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
+        ]);
     }
 
     public function getRules(): array

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Clinkards\PhpCsFixerConfig;
 
 use Clinkards\PhpCsFixerConfig\Sniffs\RemoveReadonlyPropertyAttributeOnReadonlyClass;

--- a/src/Sniffs/RemoveReadonlyPropertyAttributeOnReadonlyClass.php
+++ b/src/Sniffs/RemoveReadonlyPropertyAttributeOnReadonlyClass.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clinkards\PhpCsFixerConfig\Sniffs;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class RemoveReadonlyPropertyAttributeOnReadonlyClass extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinition
+    {
+        return new FixerDefinition(
+            'Remove readonly attribute from properties if the class is readonly.',
+            [new CodeSample('<?php readonly class Foo { readonly public int $bar; }')]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_READONLY]);
+    }
+
+    public function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $tokensCount = count($tokens);
+        for ($index = 0; $index < $tokensCount; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_CLASS)) {
+                $classIndex = $index;
+                $classModifiers = $this->getClassModifiers($tokens, $classIndex);
+                if (in_array(T_READONLY, $classModifiers)) {
+                    $this->removeReadOnlyFromProperties($tokens, $classIndex);
+                }
+            }
+        }
+    }
+
+    private function getClassModifiers(Tokens $tokens, $classIndex): array
+    {
+        $modifiers = [];
+        for ($index = $classIndex - 1; $index > 0; --$index) {
+            if ($tokens[$index]->isWhitespace()) {
+                continue;
+            }
+            if ($tokens[$index]->isGivenKind([T_FINAL, T_ABSTRACT, T_READONLY])) {
+                $modifiers[] = $tokens[$index]->getId();
+            } else {
+                break;
+            }
+        }
+
+        return $modifiers;
+    }
+
+    private function removeReadOnlyFromProperties(Tokens $tokens, $classIndex): void
+    {
+        $classStart = $tokens->getNextTokenOfKind($classIndex, ['{']);
+        $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classStart);
+
+        for ($index = $classStart + 1; $index < $classEnd; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_READONLY)) {
+                // Check the next token to see if it's whitespace and remove it if so
+                if ($tokens[$index + 1]->isWhitespace()) {
+                    $tokens->clearAt($index + 1);
+                }
+                // Clear the 'readonly' token itself
+                $tokens->clearAt($index);
+            }
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'Clinkards/remove_readonly_property';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function supports(\SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/tests/RemoveReadonlyPropertyAttributeOnReadonlyClassTest.php
+++ b/tests/RemoveReadonlyPropertyAttributeOnReadonlyClassTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clinkards\PhpCsFixerConfig\Tests;
+
+use Clinkards\PhpCsFixerConfig\Sniffs\RemoveReadonlyPropertyAttributeOnReadonlyClass;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\TestCase;
+
+final class RemoveReadonlyPropertyAttributeOnReadonlyClassTest extends TestCase
+{
+    public function testFixesReadOnlyProperties()
+    {
+        $fixer = new RemoveReadonlyPropertyAttributeOnReadonlyClass();
+        
+        $expected = '<?php readonly class Foo { public int $bar; }';
+        $input = '<?php readonly class Foo { readonly public int $bar; }';
+        
+        $tokens = Tokens::fromCode($input);
+        $fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+
+    public function testDoesNotAffectNonReadOnlyClasses()
+    {
+        $fixer = new RemoveReadonlyPropertyAttributeOnReadonlyClass();
+        
+        $expected = '<?php class Foo { readonly public int $bar; }';
+        $input = '<?php class Foo { readonly public int $bar; }';
+        
+        $tokens = Tokens::fromCode($input);
+        $fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+}


### PR DESCRIPTION
### Summary of Changes
If a class is marked as `readonly` remove the `readonly` attribute on properties.

Basically, I'm lazy and I don't want to have to worry about this again.

Full disclosure, GPT generated this, I just had to tweak it so it _actually_ worked and do some stuff around whitespace.

### To Test
Include this fixer and add a `readonly` property to a `readonly` class, it should fix it.
If it works then I made it, if it doesn't work, it's ChatGPTs fault.