### PR TITLE
Fix config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -25,10 +25,6 @@ class Config extends BaseConfig
     public function __construct(private array $extraRules = [])
     {
         parent::__construct('Clinkards - Coding Standard');
-
-        $this->registerCustomFixers([
-            new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
-        ]);
     }
 
     public function getRules(): array
@@ -38,6 +34,9 @@ class Config extends BaseConfig
 
     public function getCustomFixers(): array
     {
-        return [new LineLengthLimit()];
+        return [
+            new LineLengthLimit(),
+            new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
+        ];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Clinkards\PhpCsFixerConfig;
 
-use Gordinskiy\LineLengthChecker\Rules\LineLengthLimit;
 use Clinkards\PhpCsFixerConfig\Sniffs\RemoveReadonlyPropertyAttributeOnReadonlyClass;
+use Gordinskiy\LineLengthChecker\Rules\LineLengthLimit;
 use PhpCsFixer\Config as BaseConfig;
 
 class Config extends BaseConfig

--- a/src/Config.php
+++ b/src/Config.php
@@ -25,18 +25,15 @@ class Config extends BaseConfig
     public function __construct(private array $extraRules = [])
     {
         parent::__construct('Clinkards - Coding Standard');
+
+        $this->registerCustomFixers([
+            new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
+            new LineLengthLimit(),
+        ]);
     }
 
     public function getRules(): array
     {
         return array_merge($this->defaultRules, $this->extraRules);
-    }
-
-    public function getCustomFixers(): array
-    {
-        return [
-            new LineLengthLimit(),
-            new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
-        ];
     }
 }


### PR DESCRIPTION
### The Problem
Getting an error that 'Clinkards/remove_readonly_property' does not exist

### The Cause
`getCustomFixers` overloads the custom fixers registered by `registerCustomFixers`

### The Fix
Removed `getCustomFixers` in place of using `registerCustomFixers` as per [The Docs](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/custom_rules.rst)