### PR TITLE
[CC-875] Disable single_line_throw

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -20,6 +20,7 @@ class Config extends BaseConfig
         'fully_qualified_strict_types' => false,
         'Gordinskiy/line_length_limit' => true,
         'Clinkards/remove_readonly_property' => true,
+        'single_line_throw' => false,
     ];
 
     public function __construct(private array $extraRules = [])


### PR DESCRIPTION
### Summary of Changes
- Disables the Symfony rule whereby throw statements must be on a single line. This is because this rule conflicts with our line length limit.