### PR TITLE
Fix Fixer Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,8 +11,8 @@ use PhpCsFixer\Config as BaseConfig;
 class Config extends BaseConfig
 {
     private array $defaultRules = [
-        '@PSR12' => true,
         '@Symfony' => true,
+        '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,


### PR DESCRIPTION
### Summary of Changes
It looks like the later elements in the `$defaultRules` array take precedent over earlier elements. With this in mind, I assume we care more about the PSR-12 rules than the Symfony rules.

For example, Symfony is preventing the PSR-12 fixer from fixing functions that look like this:
```php
        $foo->bar($longArgument, $longerArgument,
            $muchLongerArgument
        );
```

To this:
```php
        $foo->bar(
            $longArgument,
            $longerArgument,
            $muchLongerArgument
        );
```

Which is coming up a fair bit in Code reviews.

#### Alternatively 
An alternative fix, if people would prefer, would be to add this to the default rules instead of changing the order:
```
        'method_argument_space' => [
            'on_multiline' => 'ensure_fully_multiline',
            'keep_multiple_spaces_after_comma' => false,
        ],
```