### PR TITLE
Add fixer for final models

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Clinkards\PhpCsFixerConfig;
 
+use Clinkards\PhpCsFixerConfig\Sniffs\RemoveFinalFromModels;
 use Clinkards\PhpCsFixerConfig\Sniffs\RemoveReadonlyPropertyAttributeOnReadonlyClass;
 use PhpCsFixer\Config as BaseConfig;
 
@@ -27,6 +28,7 @@ class Config extends BaseConfig
 
         $this->registerCustomFixers([
             new RemoveReadonlyPropertyAttributeOnReadonlyClass(),
+            new RemoveFinalFromModels(),
         ]);
     }
 

--- a/src/Sniffs/RemoveFinalFromModels.php
+++ b/src/Sniffs/RemoveFinalFromModels.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clinkards\PhpCsFixerConfig\Sniffs;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class RemoveFinalFromModels extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinition
+    {
+        return new FixerDefinition(
+            'Removes the "final" keyword from classes within namespaces like ...\Domain\Model. This is to solve the Lazy Ghost issue with Doctrine',
+            []
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_FINAL);
+    }
+
+    public function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = 0; $index < $tokens->count(); $index++) {
+            if ($tokens[$index]->isGivenKind(T_NAMESPACE)) {
+                $namespace = $this->getNamespace($tokens, $index);
+
+                // Check if the namespace contains \Domain\Model
+                if (preg_match('/\\\\Domain\\\\Model/', $namespace)) {
+                    $this->removeFinalFromClass($tokens);
+                }
+            }
+        }
+    }
+
+    private function getNamespace(Tokens $tokens, int $index): string
+    {
+        $namespace = '';
+        for ($i = $index + 1; $i < $tokens->count(); $i++) {
+            $token = $tokens[$i];
+            if ($token->equals(';')) {
+                break;
+            }
+            $namespace .= $token->getContent();
+        }
+
+        return trim($namespace);
+    }
+
+    private function removeFinalFromClass(Tokens $tokens): void
+    {
+        for ($index = 0; $index < $tokens->count(); $index++) {
+            if ($tokens[$index]->isGivenKind(T_FINAL)) {
+                // Check the next token to see if it's whitespace and remove it if so
+                if ($tokens[$index + 1]->isWhitespace()) {
+                    $tokens->clearAt($index + 1);
+                }
+                $tokens->clearAt($index);
+            }
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'Clinkards/remove_final_from_models';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+}

--- a/src/Sniffs/RemoveFinalFromModels.php
+++ b/src/Sniffs/RemoveFinalFromModels.php
@@ -7,7 +7,6 @@ namespace Clinkards\PhpCsFixerConfig\Sniffs;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Tokens;
-use SplFileInfo;
 
 final class RemoveFinalFromModels extends AbstractFixer
 {
@@ -24,9 +23,9 @@ final class RemoveFinalFromModels extends AbstractFixer
         return $tokens->isTokenKindFound(T_FINAL);
     }
 
-    public function applyFix(SplFileInfo $file, Tokens $tokens): void
+    public function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        for ($index = 0; $index < $tokens->count(); $index++) {
+        for ($index = 0; $index < $tokens->count(); ++$index) {
             if ($tokens[$index]->isGivenKind(T_NAMESPACE)) {
                 $namespace = $this->getNamespace($tokens, $index);
 
@@ -41,7 +40,7 @@ final class RemoveFinalFromModels extends AbstractFixer
     private function getNamespace(Tokens $tokens, int $index): string
     {
         $namespace = '';
-        for ($i = $index + 1; $i < $tokens->count(); $i++) {
+        for ($i = $index + 1; $i < $tokens->count(); ++$i) {
             $token = $tokens[$i];
             if ($token->equals(';')) {
                 break;
@@ -54,7 +53,7 @@ final class RemoveFinalFromModels extends AbstractFixer
 
     private function removeFinalFromClass(Tokens $tokens): void
     {
-        for ($index = 0; $index < $tokens->count(); $index++) {
+        for ($index = 0; $index < $tokens->count(); ++$index) {
             if ($tokens[$index]->isGivenKind(T_FINAL)) {
                 // Check the next token to see if it's whitespace and remove it if so
                 if ($tokens[$index + 1]->isWhitespace()) {

--- a/src/Sniffs/RemoveReadonlyPropertyAttributeOnReadonlyClass.php
+++ b/src/Sniffs/RemoveReadonlyPropertyAttributeOnReadonlyClass.php
@@ -7,7 +7,6 @@ namespace Clinkards\PhpCsFixerConfig\Sniffs;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 final class RemoveReadonlyPropertyAttributeOnReadonlyClass extends AbstractFixer

--- a/tests/RemoveFinalFromModelsTest.php
+++ b/tests/RemoveFinalFromModelsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clinkards\PhpCsFixerConfig\Tests;
+
+use Clinkards\PhpCsFixerConfig\Sniffs\RemoveFinalFromModels;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\TestCase;
+
+final class RemoveFinalFromModelsTest extends TestCase
+{
+    public function testFixesFinalModels()
+    {
+        $fixer = new RemoveFinalFromModels();
+        
+        $expected = '<?php namespace Some\Random\Domain\Model; class Foo { public int $bar; }';
+        $input = '<?php namespace Some\Random\Domain\Model; final class Foo { public int $bar; }';
+        
+        $tokens = Tokens::fromCode($input);
+        $fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+
+    public function testDoesNotRemoveFinalFromOtherNamespaces()
+    {
+        $fixer = new RemoveFinalFromModels();
+        
+        $expected = '<?php namespace Some\Random\Domain\Service; final class Foo { public int $bar; }';
+        $input = '<?php namespace Some\Random\Domain\Service; final class Foo { public int $bar; }';
+        
+        $tokens = Tokens::fromCode($input);
+        $fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+}


### PR DESCRIPTION
### Summary of Changes
- Creates a fixer to remove `final` from classes within `Domain\Model` namespaces.

I haven't enabled this by default as this issue is specific for Doctrine and we have services which have model classes that don't use Doctrine (Eg, Contact Validation Service).
Our options are either:
- Enable this on specific services
- Enable this by default