### PR TITLE
Turn off docblock to comment rule

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -21,6 +21,7 @@ class Config extends BaseConfig
         'Clinkards/remove_readonly_property' => true,
         'Clinkards/remove_final_from_models' => true,
         'single_line_throw' => false,
+        'phpdoc_to_comment' => false,
     ];
 
     public function __construct(private array $extraRules = [])


### PR DESCRIPTION
### Summary of Changes
This rule is causing some valid docblocks to be converted into comments.

This causes problems where if setting a variable to be of a certain type, it can reset the docblock to a comment causing PHPStan to moan.

Happy to close this as there is a workaround for the issue but from the sounds of it, this rule is causing more harm than good.