### PR TITLE
Fix finals check

### DIFF
--- a/src/Sniffs/RemoveFinalFromModels.php
+++ b/src/Sniffs/RemoveFinalFromModels.php
@@ -25,7 +25,7 @@ final class RemoveFinalFromModels extends AbstractFixer
                 return true;
             }
         }
-    
+
         return false;
     }
 

--- a/src/Sniffs/RemoveFinalFromModels.php
+++ b/src/Sniffs/RemoveFinalFromModels.php
@@ -20,7 +20,13 @@ final class RemoveFinalFromModels extends AbstractFixer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_FINAL);
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_FINAL) && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_CLASS)) {
+                return true;
+            }
+        }
+    
+        return false;
     }
 
     public function applyFix(\SplFileInfo $file, Tokens $tokens): void

--- a/tests/RemoveFinalFromModelsTest.php
+++ b/tests/RemoveFinalFromModelsTest.php
@@ -44,4 +44,16 @@ final class RemoveFinalFromModelsTest extends TestCase
         yield 'Test Namespace' => ['<?php namespace Stride\Test\Service\Domain\Model; final class Foo { public int $bar; }'];
         yield 'Tests Namespace' => ['<?php namespace Stride\Tests\Service\Domain\Model; final class Foo { public int $bar; }'];
     }
+
+    public function testDoesNotRemoveFinalFromMethods(): void
+    {
+        $fixer = new RemoveFinalFromModels();
+        
+        $classString = '<?php namespace Some\Random\Domain\Model; class Foo { final public function doSomething() { return $bar; } }';
+        
+        $tokens = Tokens::fromCode($classString);
+        $fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        $this->assertSame($classString, $tokens->generateCode());
+    }
 }


### PR DESCRIPTION
### The Problem
- Our fixer removes the `final` keyword from both classes and methods. It should only remove it from classes

---

### The Solution
- Add a check to make sure the candidate is on a class